### PR TITLE
test/full-sdk-coverage

### DIFF
--- a/src/clients/Client.test.js
+++ b/src/clients/Client.test.js
@@ -1,0 +1,62 @@
+const { Not3Client, NotesAPI, SystemAPI, FilesAPI } = require('../../dist/index.cjs');
+
+describe('Not3Client', () => {
+  describe('options management', () => {
+    test('getOptions returns the options passed to the constructor', () => {
+      const client = new Not3Client({ baseUrl: 'https://api.example.com/' });
+      expect(client.getOptions()).toEqual({ baseUrl: 'https://api.example.com/' });
+    });
+
+    test('setOptions replaces the options', () => {
+      const client = new Not3Client({ baseUrl: 'https://a/' });
+      client.setOptions({ baseUrl: 'https://b/', password: 'pw' });
+      expect(client.getOptions()).toEqual({ baseUrl: 'https://b/', password: 'pw' });
+    });
+
+    test('updateOptions merges with the existing options', () => {
+      const client = new Not3Client({ baseUrl: 'https://a/', password: 'pw' });
+      client.updateOptions({ password: 'new' });
+      expect(client.getOptions()).toEqual({ baseUrl: 'https://a/', password: 'new' });
+    });
+  });
+
+  describe('sub-client factories', () => {
+    const client = new Not3Client({ baseUrl: 'https://api.example.com/' });
+    test('notes() returns a NotesAPI', () => expect(client.notes()).toBeInstanceOf(NotesAPI));
+    test('system() returns a SystemAPI', () => expect(client.system()).toBeInstanceOf(SystemAPI));
+    test('files() returns a FilesAPI', () => expect(client.files()).toBeInstanceOf(FilesAPI));
+    test('each call returns a fresh instance', () => {
+      expect(client.notes()).not.toBe(client.notes());
+    });
+  });
+
+  describe('getVersionRange', () => {
+    test('is the expected v2 range', () => {
+      const client = new Not3Client({ baseUrl: 'https://a/' });
+      expect(client.getVersionRange()).toBe('>=2.0.0 <3.0.0');
+    });
+  });
+
+  describe('isCompatible', () => {
+    const client = new Not3Client({ baseUrl: 'https://a/' });
+    const fakeSystem = version => ({ info: async () => ({ version }) });
+
+    test('true when the API version is within range', async () => {
+      expect(await client.isCompatible(fakeSystem('2.5.0'))).toBe(true);
+    });
+
+    test('false when the API version is out of range', async () => {
+      expect(await client.isCompatible(fakeSystem('3.0.0'))).toBe(false);
+      expect(await client.isCompatible(fakeSystem('1.9.0'))).toBe(false);
+    });
+
+    test('always true for the IN-DEV version', async () => {
+      expect(await client.isCompatible(fakeSystem('IN-DEV'))).toBe(true);
+    });
+
+    test('false when fetching info throws', async () => {
+      const throwing = { info: async () => { throw new Error('network'); } };
+      expect(await client.isCompatible(throwing)).toBe(false);
+    });
+  });
+});

--- a/src/clients/Files.test.js
+++ b/src/clients/Files.test.js
@@ -1,0 +1,63 @@
+const { FilesAPI } = require('../../dist/index.cjs');
+
+function fakeApi(responses = {}) {
+  return {
+    get: jest.fn(async () => responses.get ?? { data: {} }),
+    post: jest.fn(async () => responses.post ?? { data: {} }),
+    put: jest.fn(async () => responses.put ?? { data: {} }),
+    delete: jest.fn(async () => responses.delete ?? { data: {} }),
+  };
+}
+
+// Note: uploadChunk() uses the module-level `axios` import (a raw PUT to a
+// presigned URL) rather than the injected instance, and axios is bundled into
+// dist/index.cjs, so it cannot be intercepted here. It is exercised indirectly
+// through FileUpload's integration test via an injected fake FilesAPI.
+
+describe('FilesAPI', () => {
+  test('startUpload posts the name and returns the upload id', async () => {
+    const api = fakeApi({ post: { data: { id: 'u1' } } });
+    const files = new FilesAPI(api, {});
+    const id = await files.startUpload('photo.png');
+    expect(api.post).toHaveBeenCalledWith('file/upload', { name: 'photo.png' });
+    expect(id).toBe('u1');
+  });
+
+  test('getUploadChunkURL passes length and part as query params', async () => {
+    const api = fakeApi({ get: { data: { url: 'https://s3/put' } } });
+    const files = new FilesAPI(api, {});
+    const url = await files.getUploadChunkURL('u1', 1234, 2);
+    expect(api.get).toHaveBeenCalledWith('file/upload/u1', { params: { length: 1234, part: 2 } });
+    expect(url).toBe('https://s3/put');
+  });
+
+  test('completeUpload puts the etags', async () => {
+    const api = fakeApi();
+    const files = new FilesAPI(api, {});
+    await files.completeUpload('u1', ['e1', 'e2']);
+    expect(api.put).toHaveBeenCalledWith('file/upload/u1', { etags: ['e1', 'e2'] });
+  });
+
+  test('getFile requests json and returns the body', async () => {
+    const api = fakeApi({ get: { data: { size: 10, url: 'https://cdn/file' } } });
+    const files = new FilesAPI(api, {});
+    const res = await files.getFile('f1');
+    expect(api.get).toHaveBeenCalledWith('file/f1', { params: { json: true } });
+    expect(res).toEqual({ size: 10, url: 'https://cdn/file' });
+  });
+
+  test('delete removes the file by id', async () => {
+    const api = fakeApi();
+    const files = new FilesAPI(api, {});
+    await files.delete('f1');
+    expect(api.delete).toHaveBeenCalledWith('file/f1');
+  });
+
+  test('getList fetches /file and returns the body', async () => {
+    const api = fakeApi({ get: { data: [{ id: 'f1' }] } });
+    const files = new FilesAPI(api, {});
+    const res = await files.getList();
+    expect(api.get).toHaveBeenCalledWith('file');
+    expect(res).toEqual([{ id: 'f1' }]);
+  });
+});

--- a/src/clients/Notes.test.js
+++ b/src/clients/Notes.test.js
@@ -1,0 +1,44 @@
+const { NotesAPI } = require('../../dist/index.cjs');
+
+/** Build a fake AxiosInstance whose methods resolve to the given { data } payloads. */
+function fakeApi(responses = {}) {
+  return {
+    get: jest.fn(async () => responses.get ?? { data: {} }),
+    post: jest.fn(async () => responses.post ?? { data: {} }),
+    put: jest.fn(async () => responses.put ?? { data: {} }),
+    delete: jest.fn(async () => responses.delete ?? { data: {} }),
+  };
+}
+
+describe('NotesAPI', () => {
+  test('create posts to note/json and returns the response body', async () => {
+    const api = fakeApi({ post: { data: { id: 'n1', token: 't1' } } });
+    const notes = new NotesAPI(api, {});
+    const req = { content: 'hello' };
+    const res = await notes.create(req);
+    expect(api.post).toHaveBeenCalledWith('note/json', req);
+    expect(res).toEqual({ id: 'n1', token: 't1' });
+  });
+
+  test('get fetches note/<id>/json and returns the body', async () => {
+    const api = fakeApi({ get: { data: { content: 'hi' } } });
+    const notes = new NotesAPI(api, {});
+    const res = await notes.get('n1');
+    expect(api.get).toHaveBeenCalledWith('note/n1/json');
+    expect(res).toEqual({ content: 'hi' });
+  });
+
+  test('delete sends the token in the request body', async () => {
+    const api = fakeApi();
+    const notes = new NotesAPI(api, {});
+    await notes.delete('n1', 'tok');
+    expect(api.delete).toHaveBeenCalledWith('note/n1', { data: { token: 'tok' } });
+  });
+
+  test('delete works without a token', async () => {
+    const api = fakeApi();
+    const notes = new NotesAPI(api, {});
+    await notes.delete('n1');
+    expect(api.delete).toHaveBeenCalledWith('note/n1', { data: { token: undefined } });
+  });
+});

--- a/src/clients/System.test.js
+++ b/src/clients/System.test.js
@@ -1,0 +1,43 @@
+const { SystemAPI } = require('../../dist/index.cjs');
+
+function fakeApi(responses = {}) {
+  return {
+    get: jest.fn(async () => responses.get ?? { data: {} }),
+    post: jest.fn(async () => responses.post ?? { data: {} }),
+    put: jest.fn(async () => responses.put ?? { data: {} }),
+    delete: jest.fn(async () => responses.delete ?? { data: {} }),
+  };
+}
+
+describe('SystemAPI', () => {
+  test('info fetches /info and returns the body', async () => {
+    const api = fakeApi({ get: { data: { version: '2.1.0' } } });
+    const system = new SystemAPI(api, {});
+    const res = await system.info();
+    expect(api.get).toHaveBeenCalledWith('info');
+    expect(res).toEqual({ version: '2.1.0' });
+  });
+
+  test('info caches the response (only one HTTP call)', async () => {
+    const api = fakeApi({ get: { data: { version: '2.1.0' } } });
+    const system = new SystemAPI(api, {});
+    await system.info();
+    await system.info();
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('stats fetches /stats and forwards the password as a query param', async () => {
+    const api = fakeApi({ get: { data: { notes: 5 } } });
+    const system = new SystemAPI(api, {});
+    const res = await system.stats('secret');
+    expect(api.get).toHaveBeenCalledWith('stats', { params: { password: 'secret' } });
+    expect(res).toEqual({ notes: 5 });
+  });
+
+  test('stats works without a password', async () => {
+    const api = fakeApi({ get: { data: {} } });
+    const system = new SystemAPI(api, {});
+    await system.stats();
+    expect(api.get).toHaveBeenCalledWith('stats', { params: { password: undefined } });
+  });
+});

--- a/src/lib/Crypto.test.js
+++ b/src/lib/Crypto.test.js
@@ -1,6 +1,39 @@
 const { Crypto } = require('../../dist/index.cjs');
 
 describe('Crypto', () => {
+  describe('encoding helpers', () => {
+    test('buf2base / base2buf round-trip', () => {
+      const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+      const b64 = Crypto.buf2base(bytes);
+      expect(typeof b64).toBe('string');
+      const back = new Uint8Array(Crypto.base2buf(b64));
+      expect(Array.from(back)).toEqual(Array.from(bytes));
+    });
+
+    test('generateSeed returns a 32-byte base64 seed', () => {
+      const seed = Crypto.generateSeed();
+      expect(new Uint8Array(Crypto.base2buf(seed)).byteLength).toBe(Crypto.AES_SEED_LENGTH);
+      expect(Crypto.AES_SEED_LENGTH).toBe(32);
+    });
+
+    test('generateSeed is random (two seeds differ)', () => {
+      expect(Crypto.generateSeed()).not.toBe(Crypto.generateSeed());
+    });
+  });
+
+  describe('generateKey', () => {
+    test('rejects a seed of the wrong length', async () => {
+      const shortSeed = Crypto.buf2base(new Uint8Array(8));
+      await expect(Crypto.generateKey(shortSeed)).rejects.toThrow('Invalid seed length');
+    });
+
+    test('accepts a valid seed for both modes', async () => {
+      const seed = Crypto.generateSeed();
+      await expect(Crypto.generateKey(seed, 'cbc')).resolves.toBeDefined();
+      await expect(Crypto.generateKey(seed, 'gcm')).resolves.toBeDefined();
+    });
+  });
+
   ['cbc', 'gcm'].forEach(mode => {
     describe(`Crypto${mode.toUpperCase()}`, () => {
       test(`encrypt/decrypt string`, async () => {
@@ -53,6 +86,24 @@ describe('Crypto', () => {
         const encString = Crypto.buf2base(new Uint8Array(encBuffer));
         const dec = await Crypto.decrypt(encString, key, mode);
         expect(dec).toBe(msg);
+      });
+
+      test(`decrypt with the wrong key fails`, async () => {
+        const key = await Crypto.generateKey(Crypto.generateSeed(), mode);
+        const wrongKey = await Crypto.generateKey(Crypto.generateSeed(), mode);
+        const enc = await Crypto.encrypt('secret', key, mode);
+        await expect(Crypto.decrypt(enc, wrongKey, mode)).rejects.toThrow();
+      });
+
+      test(`tampering with the ciphertext is detected`, async () => {
+        const seed = Crypto.generateSeed();
+        const key = await Crypto.generateKey(seed, mode);
+        const enc = new Uint8Array(await Crypto.encrypt(
+          new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer, key, mode,
+        ));
+        // Flip a byte in the encrypted body (past the IV).
+        enc[enc.length - 1] ^= 0xff;
+        await expect(Crypto.decrypt(enc.buffer, key, mode)).rejects.toThrow();
       });
     });
   });

--- a/src/lib/FileDownload.test.js
+++ b/src/lib/FileDownload.test.js
@@ -1,0 +1,108 @@
+const { FileDownload, FileUpload, Crypto } = require('../../dist/index.cjs');
+
+function fakeFilesApi(file) {
+  return { getFile: jest.fn(async () => file) };
+}
+
+/** Build a fetch stub whose response body streams `bytes` across `reads` chunks. */
+function stubFetch(bytes, reads = 1) {
+  const size = Math.ceil(bytes.length / reads);
+  const slices = [];
+  for (let i = 0; i < bytes.length; i += size) slices.push(bytes.slice(i, i + size));
+  if (slices.length === 0) slices.push(new Uint8Array());
+  global.fetch = jest.fn(async () => ({
+    body: {
+      getReader() {
+        let i = 0;
+        return {
+          read: async () =>
+            i < slices.length
+              ? { done: false, value: slices[i++] }
+              : { done: true, value: undefined },
+        };
+      },
+    },
+  }));
+}
+
+describe('FileDownload', () => {
+  const realFetch = global.fetch;
+  afterEach(() => { global.fetch = realFetch; jest.restoreAllMocks(); });
+
+  describe('guards before prepare', () => {
+    test('getFileMetadata throws', () => {
+      const dl = new FileDownload(fakeFilesApi(), 'f1', Crypto.generateSeed());
+      expect(() => dl.getFileMetadata()).toThrow('Download not prepared');
+    });
+    test('getTotalChunks throws', () => {
+      const dl = new FileDownload(fakeFilesApi(), 'f1', Crypto.generateSeed());
+      expect(() => dl.getTotalChunks()).toThrow('Download not prepared');
+    });
+  });
+
+  describe('prepare / metadata', () => {
+    test('prepare fetches metadata and exposes it', async () => {
+      const file = { size: 123, url: 'https://cdn/f1' };
+      const api = fakeFilesApi(file);
+      const dl = new FileDownload(api, 'f1', Crypto.generateSeed());
+      await dl.prepare();
+      expect(api.getFile).toHaveBeenCalledWith('f1');
+      expect(dl.getFileMetadata()).toEqual(file);
+    });
+
+    test('getTotalChunks divides the encrypted size by CHUNK_SIZE', async () => {
+      const api = fakeFilesApi({ size: FileUpload.CHUNK_SIZE * 2 + 1, url: 'x' });
+      const dl = new FileDownload(api, 'f1', Crypto.generateSeed());
+      await dl.prepare();
+      expect(dl.getTotalChunks()).toBe(3);
+    });
+  });
+
+  describe('start (decrypts a streamed file)', () => {
+    async function encryptPayload(seed, payload) {
+      const key = await Crypto.generateKey(seed); // cbc, matches FileDownload
+      const enc = await Crypto.encrypt(payload.buffer, key);
+      return new Uint8Array(enc);
+    }
+
+    test('decrypts a single sub-chunk file', async () => {
+      const seed = Crypto.generateSeed();
+      const payload = new Uint8Array([10, 20, 30, 40, 50]);
+      const encBytes = await encryptPayload(seed, payload);
+      stubFetch(encBytes, 1);
+
+      const api = fakeFilesApi({ size: payload.length, url: 'https://cdn/f1' });
+      const dl = new FileDownload(api, 'f1', seed);
+      await dl.prepare();
+
+      const received = [];
+      await dl.start(async (buf, index) => received.push({ data: new Uint8Array(buf), index }));
+
+      expect(received).toHaveLength(1);
+      expect(received[0].index).toBe(0);
+      expect(Array.from(received[0].data)).toEqual(Array.from(payload));
+    });
+
+    test('accumulates across multiple stream reads before decrypting', async () => {
+      const seed = Crypto.generateSeed();
+      const payload = new Uint8Array(Array.from({ length: 64 }, (_, i) => i));
+      const encBytes = await encryptPayload(seed, payload);
+      stubFetch(encBytes, 4); // deliver the ciphertext in 4 pieces
+
+      const api = fakeFilesApi({ size: payload.length, url: 'https://cdn/f1' });
+      const dl = new FileDownload(api, 'f1', seed);
+      await dl.prepare();
+
+      const received = [];
+      await dl.start(async (buf, index) => received.push({ data: new Uint8Array(buf), index }));
+
+      expect(received).toHaveLength(1);
+      expect(Array.from(received[0].data)).toEqual(Array.from(payload));
+    });
+
+    test('start before prepare throws', async () => {
+      const dl = new FileDownload(fakeFilesApi(), 'f1', Crypto.generateSeed());
+      await expect(dl.start(async () => {})).rejects.toThrow('Download not prepared');
+    });
+  });
+});

--- a/src/lib/FileUpload.test.js
+++ b/src/lib/FileUpload.test.js
@@ -1,0 +1,136 @@
+const { FileUpload, Crypto } = require('../../dist/index.cjs');
+
+/** A fake FilesAPI that records the upload flow and hands back synthetic etags. */
+function fakeFilesApi(overrides = {}) {
+  return {
+    startUpload: jest.fn(async () => 'upload-1'),
+    getUploadChunkURL: jest.fn(async (id, length, part) => `https://s3/${part}`),
+    uploadChunk: jest.fn(async (url) => `etag-${url}`),
+    completeUpload: jest.fn(async () => {}),
+    delete: jest.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+/** getBytes that returns deterministic buffers of the requested length. */
+const getBytes = async (start, end) => new Uint8Array(end - start).fill(7).buffer;
+
+describe('FileUpload', () => {
+  const SEED = Crypto.generateSeed();
+
+  describe('chunk math', () => {
+    test('getChunkCount divides by the crypto-adjusted chunk size', () => {
+      const up = new FileUpload(fakeFilesApi(), 'f', 0, 1, true, SEED);
+      expect(up.getChunkCount()).toBe(0);
+      const one = new FileUpload(fakeFilesApi(), 'f', 100, 1, true, SEED);
+      expect(one.getChunkCount()).toBe(1);
+      const three = new FileUpload(fakeFilesApi(), 'f', FileUpload.ACTUAL_CHUNK_SIZE * 2 + 1, 1, true, SEED);
+      expect(three.getChunkCount()).toBe(3);
+    });
+
+    test('ACTUAL_CHUNK_SIZE is CHUNK_SIZE minus the AES-CBC header', () => {
+      expect(FileUpload.ACTUAL_CHUNK_SIZE).toBe(FileUpload.CHUNK_SIZE - Crypto.AES_CBC_HEADER_BYTES);
+    });
+
+    test('getEncryptedSize is a multiple of CHUNK_SIZE', () => {
+      const up = new FileUpload(fakeFilesApi(), 'f', 100, 1, true, SEED);
+      expect(up.getEncryptedSize()).toBe(FileUpload.CHUNK_SIZE);
+    });
+  });
+
+  describe('state guards before start', () => {
+    test('getID throws', () => {
+      expect(() => new FileUpload(fakeFilesApi(), 'f', 100).getID()).toThrow('Upload not started');
+    });
+    test('getProgress throws', () => {
+      expect(() => new FileUpload(fakeFilesApi(), 'f', 100).getProgress()).toThrow('Upload not started');
+    });
+    test('cancel throws', async () => {
+      await expect(new FileUpload(fakeFilesApi(), 'f', 100).cancel()).rejects.toThrow('Upload not started');
+    });
+    test('isStarted/isFinished are false', () => {
+      const up = new FileUpload(fakeFilesApi(), 'f', 100);
+      expect(up.isStarted()).toBe(false);
+      expect(up.isFinished()).toBe(false);
+    });
+    test('getSeed returns the provided seed', () => {
+      expect(new FileUpload(fakeFilesApi(), 'f', 100, 1, true, SEED).getSeed()).toBe(SEED);
+    });
+  });
+
+  describe('start (single chunk, happy path)', () => {
+    test('runs the full upload flow and finishes', async () => {
+      const api = fakeFilesApi();
+      const up = new FileUpload(api, 'file.bin', 1000, 1, true, SEED);
+      await up.start(getBytes);
+
+      expect(api.startUpload).toHaveBeenCalledWith('file.bin');
+      // part number is 1-indexed; length is the encrypted byte length.
+      expect(api.getUploadChunkURL).toHaveBeenCalledTimes(1);
+      const [, encLength, part] = api.getUploadChunkURL.mock.calls[0];
+      expect(part).toBe(1);
+      expect(encLength).toBeGreaterThan(1000);
+      expect(api.uploadChunk).toHaveBeenCalledTimes(1);
+      expect(api.completeUpload).toHaveBeenCalledTimes(1);
+      const [, etags] = api.completeUpload.mock.calls[0];
+      expect(etags).toEqual(['etag-https://s3/1']);
+
+      expect(up.isFinished()).toBe(true);
+      expect(up.isStarted()).toBe(true);
+      expect(up.getID()).toBe('upload-1');
+      expect(up.getProgress()[0].state).toBe('done');
+      expect(up.getProgress()[0].etag).toBe('etag-https://s3/1');
+    });
+
+    test('fires the progress hook', async () => {
+      const up = new FileUpload(fakeFilesApi(), 'file.bin', 1000, 1, true, SEED);
+      const states = [];
+      up.onProgress(p => { if (p[0]) states.push(p[0].state); });
+      await up.start(getBytes);
+      expect(states).toEqual(expect.arrayContaining(['read', 'crypto', 'upload', 'done']));
+    });
+
+    test('starting twice throws', async () => {
+      const up = new FileUpload(fakeFilesApi(), 'file.bin', 1000, 1, true, SEED);
+      await up.start(getBytes);
+      await expect(up.start(getBytes)).rejects.toThrow('Upload already started');
+    });
+  });
+
+  describe('failure handling', () => {
+    test('cancels the upload when a chunk read throws (cancelOnError)', async () => {
+      const api = fakeFilesApi();
+      const up = new FileUpload(api, 'file.bin', 1000, 1, true, SEED);
+      const boom = async () => { throw new Error('read failed'); };
+      await expect(up.start(boom)).rejects.toThrow('read failed');
+      expect(api.delete).toHaveBeenCalledWith('upload-1');
+      expect(up.isFinished()).toBe(false);
+    });
+
+    test('does not auto-cancel when cancelOnError is false', async () => {
+      const api = fakeFilesApi();
+      const up = new FileUpload(api, 'file.bin', 1000, 1, false, SEED);
+      const boom = async () => { throw new Error('read failed'); };
+      await expect(up.start(boom)).rejects.toThrow('read failed');
+      expect(api.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resume', () => {
+    test('resumes with a supplied upload id', async () => {
+      const api = fakeFilesApi();
+      const up = new FileUpload(api, 'file.bin', 1000, 1, true, SEED);
+      await up.resume(getBytes, { id: 'resumed-1', progress: {} });
+      expect(api.startUpload).not.toHaveBeenCalled();
+      expect(api.completeUpload).toHaveBeenCalledTimes(1);
+      const [id] = api.completeUpload.mock.calls[0];
+      expect(id).toBe('resumed-1');
+      expect(up.isFinished()).toBe(true);
+    });
+
+    test('throws when no id is available to resume', async () => {
+      const up = new FileUpload(fakeFilesApi(), 'file.bin', 1000, 1, true, SEED);
+      await expect(up.resume(getBytes)).rejects.toThrow('No upload ID provided');
+    });
+  });
+});

--- a/src/lib/FragmentData.test.js
+++ b/src/lib/FragmentData.test.js
@@ -1,0 +1,90 @@
+const { FragmentData, Crypto } = require('../../dist/index.cjs');
+
+describe('FragmentData', () => {
+  describe('constructor defaults', () => {
+    test('applies defaults when only a seed is given', () => {
+      const f = new FragmentData({ seed: 'abc' });
+      expect(f.seed).toBe('abc');
+      expect(f.server).toBeNull();
+      expect(f.selfDestruct).toBe(false);
+      expect(f.cryptoMode).toBe('cbc');
+    });
+
+    test('keeps provided values', () => {
+      const f = new FragmentData({
+        seed: 'abc',
+        server: 'https://api.example.com/',
+        selfDestruct: true,
+        cryptoMode: 'gcm',
+      });
+      expect(f.server).toBe('https://api.example.com/');
+      expect(f.selfDestruct).toBe(true);
+      expect(f.cryptoMode).toBe('gcm');
+    });
+
+    test('coerces an empty-string server to null', () => {
+      const f = new FragmentData({ seed: 'abc', server: '' });
+      expect(f.server).toBeNull();
+    });
+  });
+
+  describe('toString', () => {
+    test('omits defaults (no server, cbc, no self-destruct)', () => {
+      const f = new FragmentData({ seed: 'abc' });
+      const decoded = atob(f.toString());
+      const params = new URLSearchParams(decoded);
+      expect(params.get('k')).toBe('abc');
+      expect(params.has('s')).toBe(false);
+      expect(params.has('d')).toBe(false);
+      expect(params.has('m')).toBe(false);
+    });
+
+    test('includes non-default values', () => {
+      const f = new FragmentData({
+        seed: 'abc',
+        server: 'https://api.example.com/',
+        selfDestruct: true,
+        cryptoMode: 'gcm',
+      });
+      const params = new URLSearchParams(atob(f.toString()));
+      expect(params.get('s')).toBe('https://api.example.com/');
+      expect(params.get('d')).toBe('1');
+      expect(params.get('m')).toBe('gcm');
+    });
+  });
+
+  describe('fromURL', () => {
+    test('parses a fragment produced by toString', () => {
+      const original = new FragmentData({
+        seed: Crypto.generateSeed(),
+        server: 'https://api.example.com/',
+        selfDestruct: true,
+        cryptoMode: 'gcm',
+      });
+      const url = `https://ui.example.com/q/note1#${original.toString()}`;
+      const parsed = FragmentData.fromURL(url);
+      expect(parsed.seed).toBe(original.seed);
+      expect(parsed.server).toBe(original.server);
+      expect(parsed.selfDestruct).toBe(true);
+      expect(parsed.cryptoMode).toBe('gcm');
+    });
+
+    test('round-trips seeds containing "+" and "/" (500 random seeds)', () => {
+      for (let i = 0; i < 500; i++) {
+        const seed = Crypto.generateSeed();
+        const url = `https://ui/#${new FragmentData({ seed }).toString()}`;
+        expect(FragmentData.fromURL(url).seed).toBe(seed);
+      }
+    });
+
+    test('defaults cryptoMode to cbc when "m" is absent', () => {
+      const url = `https://ui/#${new FragmentData({ seed: 'abc' }).toString()}`;
+      expect(FragmentData.fromURL(url).cryptoMode).toBe('cbc');
+    });
+
+    test('throws when the seed is missing', () => {
+      const fragment = btoa(new URLSearchParams({ d: '1' }).toString());
+      expect(() => FragmentData.fromURL(`https://ui/#${fragment}`)).toThrow('Seed is required');
+    });
+  });
+});

--- a/src/lib/FragmentData.test.js
+++ b/src/lib/FragmentData.test.js
@@ -69,7 +69,23 @@ describe('FragmentData', () => {
       expect(parsed.cryptoMode).toBe('gcm');
     });
 
-    test('round-trips seeds containing "+" and "/" (500 random seeds)', () => {
+    test('round-trips seeds containing "+", "/" and "=" (deterministic)', () => {
+      // These are the base64 characters that are unsafe in a query string:
+      // '+' would otherwise decode back to a space. Cover them explicitly so
+      // the edge case is exercised on every run, not just probabilistically.
+      const seeds = [
+        'ab+cd/ef==',
+        '+++///===',
+        'In89tNsi54tjvgOsNZ/ykCGgqokz7rzD+iu8YPOtu8s=',
+        'a+b/c+d/e+f/=',
+      ];
+      for (const seed of seeds) {
+        const url = `https://ui/#${new FragmentData({ seed }).toString()}`;
+        expect(FragmentData.fromURL(url).seed).toBe(seed);
+      }
+    });
+
+    test('round-trips arbitrary generated seeds (fuzz, 500 random)', () => {
       for (let i = 0; i < 500; i++) {
         const seed = Crypto.generateSeed();
         const url = `https://ui/#${new FragmentData({ seed }).toString()}`;

--- a/src/lib/ShareGenerator.test.js
+++ b/src/lib/ShareGenerator.test.js
@@ -1,14 +1,78 @@
-const { ShareGenerator } = require('../../dist/index.cjs');
+const { ShareGenerator, FragmentData } = require('../../dist/index.cjs');
 
 describe('ShareGenerator', () => {
-  const gen = new ShareGenerator({ apiUrl: 'https://api.example.com/' });
+  const opts = {
+    uiUrl: 'https://ui.example.com/',
+    apiUrl: 'https://api.example.com/',
+  };
+  const gen = new ShareGenerator(opts);
 
-  test('noteServerSideDecrypt percent-encodes the seed', () => {
-    const seed = 'ab+cd/ef==';
-    const url = gen.noteServerSideDecrypt('note123', seed);
-    expect(url).toBe('https://api.example.com/note/note123/decrypt?key=ab%2Bcd%2Fef%3D%3D');
-    // The parsed key must match the original seed exactly.
-    const parsed = new URL(url).searchParams.get('key');
-    expect(parsed).toBe(seed);
+  describe('noteUi', () => {
+    test('builds a note UI link from a seed string', () => {
+      const url = gen.noteUi('note1', 'seed123');
+      expect(url.startsWith('https://ui.example.com/q/note1#')).toBe(true);
+      const fragment = FragmentData.fromURL(url);
+      expect(fragment.seed).toBe('seed123');
+      // storeServer defaults to false -> server not embedded.
+      expect(fragment.server).toBeNull();
+    });
+
+    test('accepts a FragmentData instance directly', () => {
+      const frag = new FragmentData({ seed: 'seedX', cryptoMode: 'gcm' });
+      const url = gen.noteUi('note2', frag);
+      const parsed = FragmentData.fromURL(url);
+      expect(parsed.seed).toBe('seedX');
+      expect(parsed.cryptoMode).toBe('gcm');
+    });
+
+    test('embeds the API server when storeServer is enabled', () => {
+      const genStore = new ShareGenerator({ ...opts, storeServer: true });
+      const url = genStore.noteUi('note3', 'seedY');
+      expect(FragmentData.fromURL(url).server).toBe(opts.apiUrl);
+    });
+  });
+
+  describe('fileUi', () => {
+    test('builds a file UI link', () => {
+      const url = gen.fileUi('file1', 'seedF');
+      expect(url.startsWith('https://ui.example.com/f/file1#')).toBe(true);
+      expect(FragmentData.fromURL(url).seed).toBe('seedF');
+    });
+
+    test('embeds the API server when storeServer is enabled', () => {
+      const genStore = new ShareGenerator({ ...opts, storeServer: true });
+      const url = genStore.fileUi('file2', 'seedF2');
+      expect(FragmentData.fromURL(url).server).toBe(opts.apiUrl);
+    });
+  });
+
+  describe('curl commands', () => {
+    test('noteCurl targets the raw note endpoint', () => {
+      const cmd = gen.noteCurl('note1', 'seed1');
+      expect(cmd).toContain('decrypt-note.sh');
+      expect(cmd).toContain('https://api.example.com/note/note1/raw seed1');
+    });
+
+    test('noteCurlSave appends an output redirect', () => {
+      const cmd = gen.noteCurlSave('note1', 'seed1', 'out.txt');
+      expect(cmd.endsWith(' > out.txt')).toBe(true);
+      expect(cmd).toContain('decrypt-note.sh');
+    });
+
+    test('fileCurl targets the file endpoint with a filename', () => {
+      const cmd = gen.fileCurl('file1', 'seed1', 'out.bin');
+      expect(cmd).toContain('decrypt-file.sh');
+      expect(cmd).toContain('https://api.example.com/file/file1 seed1 out.bin');
+    });
+  });
+
+  describe('noteServerSideDecrypt', () => {
+    test('percent-encodes the seed', () => {
+      const seed = 'ab+cd/ef==';
+      const url = gen.noteServerSideDecrypt('note123', seed);
+      expect(url).toBe('https://api.example.com/note/note123/decrypt?key=ab%2Bcd%2Fef%3D%3D');
+      // The parsed key must match the original seed exactly.
+      expect(new URL(url).searchParams.get('key')).toBe(seed);
+    });
   });
 });


### PR DESCRIPTION
## Description

Adds comprehensive test coverage across the SDK, growing the suite from 4 tests to **85 tests across 9 suites**. Previously only `Crypto` had any tests.

> **Note:** This branch is stacked on top of #69 (`fix/crypto-encoding-share-url-etag`). Until #69 is merged, this PR's diff also shows the three bug-fix commits. Merge #69 first, then this diff reduces to the test files only.

### What is covered

| Suite | Coverage |
| --- | --- |
| `Crypto` | encoding helpers, seed/key generation + errors, unicode & large strings, legacy Latin-1 fallback, wrong-key & tamper detection |
| `FragmentData` | constructor defaults, `toString`, `fromURL` round-trip (incl. 500 random `+`/`/` seeds), error paths |
| `ShareGenerator` | every link/command method, incl. `storeServer` behavior |
| `NotesAPI` / `SystemAPI` / `FilesAPI` | request URL/params/body and return values via injected fake axios; info-caching |
| `Not3Client` | options merge, sub-client factories, version range, `isCompatible` (in-range / out / IN-DEV / throws) |
| `FileUpload` | chunk math, state guards, full upload flow, progress hook, resume, crash → auto-cancel |
| `FileDownload` | guards, metadata, chunk count, real encrypt→stream→decrypt round-trip across multiple reads |

### Approach

Tests follow the existing convention of running against the built bundle (`dist/index.cjs`). API-dependent classes are exercised through their **constructor-injected dependencies** (fake axios instance / fake `FilesAPI`) and a **stubbed global `fetch`**, so no HTTP mocking framework or new dependencies are required.

The one spot not directly unit-tested is `FilesAPI.uploadChunk`'s raw PUT (it uses the module-level `axios` import, which is bundled into `dist` and cannot be intercepted); it is exercised indirectly through the `FileUpload` flow. This is documented in `src/clients/Files.test.js`.

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation if needed
- [x] This PR follows the project's coding style

## Additional Notes

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
